### PR TITLE
upgrade to proper v1.2

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -297,8 +297,8 @@ pkg_backoff_name = backoff
 pkg_backoff_description = Simple exponential backoffs in Erlang
 pkg_backoff_homepage = https://github.com/ferd/backoff
 pkg_backoff_fetch = git
-pkg_backoff_repo = https://github.com/ferd/backoff
-pkg_backoff_commit = master
+pkg_backoff_repo = https://github.com/hammerandchisel/backoff
+pkg_backoff_commit = c096c86ba751fc53f74410e7ed6478dab4722234
 
 PACKAGES += barrel_tcp
 pkg_barrel_tcp_name = barrel_tcp


### PR DESCRIPTION
we're actually getting an old version through backoff. later we'll want
to swap back to the main repo, but until it points to v1.2 of proper, we
point at our fork